### PR TITLE
Fix incorrect state var scoping

### DIFF
--- a/t/01-parser.t
+++ b/t/01-parser.t
@@ -36,7 +36,7 @@ plan 2;
 #Try each test indivigually.
 subtest {
     for @commits -> $c {
-        ok Git::Log::Parser.parse($c), "Can parse commit, index {$++}";
+        ok Git::Log::Parser.parse($c), "Can parse commit, index $($++)";
     }
 }
 


### PR DESCRIPTION
I was meant to just submit an Issue, but the Issues tab is closed. How come?

Bug report:

-------------------------

Haven't run the code and just spotted this while reviewing some ecosystem code.

The `{$++}"` needs to be changed to `$($++)"` or to `" ~ $++`

With original version, the state var is in its own block, which gets cloned when the outer block is entered, so the var ends up always being set to `1`.

```perl6
m: for ^3 { say "and {++$}"; }
rakudo-moar e9351cbaa: OUTPUT: «and 1␤and 1␤and 1␤»

m: for ^3 { say "and $(++$)"; }
rakudo-moar e9351cbaa: OUTPUT: «and 1␤and 2␤and 3␤»
m: for ^3 { say "and " ~ ++$; }
rakudo-moar e9351cbaa: OUTPUT: «and 1␤and 2␤and 3␤»
```